### PR TITLE
Forcing git diff to not use colorized output

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -317,7 +317,7 @@ async function run(requestedVersion, cliArgs) {
     await exec('git commit -m "New version" --allow-empty', verbose);
 
     log.info('Generate the patch between the 2 versions');
-    const diffOutput = await exec('git diff HEAD~1 HEAD', verbose);
+    const diffOutput = await exec('git diff HEAD~1 HEAD --no-color', verbose);
 
     log.info('Save the patch in temp directory');
     const patchPath = path.resolve(tmpDir, `upgrade_${currentVersion}_${newVersion}.patch`);


### PR DESCRIPTION
If a user sets `color.ui` or `color.diff` to `always` in their git configuration files, the output of `git diff` will contain some "color characters" as well as the diff. When you try to apply this diff with color characters with `git apply` you will get `fatal: unrecognized input`. 

I think this is the cause of issue #11543

Reproduce in git with: 
```
mkdir git-test
cd git-test/
git init
echo "foo" > bar.txt
git add bar.txt
git commit -m "First"
echo "foomobile" > bar.txt
git add bar.txt
git diff HEAD > new.patch --color=always
git reset --hard HEAD
git apply new.patch --check
```

Set `--color=never` or `--no-color` and the unrecognized input error should disappear and the patch be applied successfully.